### PR TITLE
Add iOS 6 support

### DIFF
--- a/Demonstration/Demonstration.xcodeproj/project.pbxproj
+++ b/Demonstration/Demonstration.xcodeproj/project.pbxproj
@@ -393,6 +393,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Demonstration/Demonstration-Prefix.pch";
 				INFOPLIST_FILE = "Demonstration/Demonstration-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -406,6 +407,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Demonstration/Demonstration-Prefix.pch";
 				INFOPLIST_FILE = "Demonstration/Demonstration-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};

--- a/MBAutoGrowingTextView.podspec
+++ b/MBAutoGrowingTextView.podspec
@@ -4,11 +4,11 @@ Pod::Spec.new do |s|
   s.summary      = "An auto-layout based light-weight UITextView subclass which automatically grows and shrinks based on the size of user input"
 
   s.description  = <<-DESC
-		An auto-layout based light-weight UITextView subclass which automatically grows and shrinks based on the size of 
+		An auto-layout based light-weight UITextView subclass which automatically grows and shrinks based on the size of
 		user input and can be constrained by maximal and minimal height - all without a single line of code.
 
-		Made primarely for use in Interface builder and only works with Auto layout.			
-		
+		Made primarely for use in Interface builder and only works with Auto layout.
+
 		Main features:
 		* Made for iOS 7, fully leveraging Interface builder and Auto layout.
 		* UITextView's height will automatically grow or shrink based on amount of text entered by user
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.author             = { "Matej Balantič" => "matej@balantic.si" }
   s.screenshots = [ 	"https://raw.githubusercontent.com/MatejBalantic/MBDocs/master/MBAutoGrowingTextView/animated.gif"]
   s.social_media_url = "http://twitter.com/skavt"
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '6.0'
   s.source       = { :git => "https://github.com/MatejBalantic/MBAutoGrowingTextView.git", :tag => "0.1.0" }
   s.source_files  = 'MBAutoGrowingTextView/*.{h,m}'
   s.requires_arc = true

--- a/MBAutoGrowingTextView/MBAutoGrowingTextView.m
+++ b/MBAutoGrowingTextView/MBAutoGrowingTextView.m
@@ -71,8 +71,14 @@
              a view with valid auto-layout constraints.");
     
     // calculate size needed for the text to be visible without scrolling
-    CGSize sizeThatFits = [self sizeThatFits:self.frame.size];
-    float newHeight = sizeThatFits.height;
+    CGFloat newHeight;
+    BOOL iOS7 = kCFCoreFoundationVersionNumber > kCFCoreFoundationVersionNumber_iOS_6_1;
+    if (iOS7) {
+        CGSize sizeThatFits = [self sizeThatFits:self.frame.size];
+        newHeight = sizeThatFits.height;
+    } else {
+        newHeight = self.contentSize.height;
+    }
 
     // if there is any minimal height constraint set, make sure we consider that
     if (self.maxHeightConstraint) {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Auto layout is a great way to design your interfaces in a modern iOS application
 * UITextView's height will automatically grow or shrink based on amount of text entered by user
 * Maximal and minimal height of the UITextView can be defined from the interface builder
 * When maximal height is reached, UITextView content becomes scrollable
+* Supports iOS 6 if `scrollEnabled` is set to NO (has small visual glitches on iOS 6 if scrolling is enabled)
 * **Not a single line of code required** for complete functionality
 
 ![Animated demo](https://raw.githubusercontent.com/MatejBalantic/MBDocs/master/MBAutoGrowingTextView/animated.gif)


### PR DESCRIPTION
Turns out that supporting iOS 6 is trivial, provided that `scrollEnabled == NO`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/matejbalantic/mbautogrowingtextview/2)
<!-- Reviewable:end -->
